### PR TITLE
fix: add timezone import in login_manager

### DIFF
--- a/src/quart_login/login_manager.py
+++ b/src/quart_login/login_manager.py
@@ -1,6 +1,5 @@
-import warnings
-from datetime import datetime
-from datetime import timedelta
+# isort: skip_file
+from datetime import datetime, timedelta, timezone
 
 from quart import (
     has_request_context,


### PR DESCRIPTION
`datetime.timezone` was missing in `login_manager`.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add the `timezone` import to `login_manager.py` and consolidate datetime-related imports.

### Why are these changes being made?

The `timezone` import is necessary for handling timezone-aware datetime objects, which was previously missing and could lead to errors. Consolidating the imports improves code readability and organization.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->